### PR TITLE
Design 2 - No Network

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Properly detect languages on Github
+*.h linguist-language=cpp
+*.inc linguist-language=cpp
+thirdparty/* linguist-vendored
+
+# Normalize EOL for all files that Git considers text files
+* text=auto eol=lf
+# Except for bat files, which are Windows only files
+*.bat eol=crlf
+# And some test files where the EOL matters
+*.test.txt -text
+
+# The above only works properly for Git 2.10+, so for older versions
+# we need to manually list the binary files we don't want modified.
+*.icns binary
+*.ico binary
+*.jar binary
+*.png binary
+*.ttf binary
+*.tza binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+.DS_Store
+.vscode/
+.sconsign.dblite
+.godot
+wasmer/
+addons.zip
+*.os
+*.obj
+*.pdb
+*.idb
+*.so
+*.dylib
+*.dll
+*.o
+*.exp
+*.lib
+__pycache__

--- a/include/audio_stream_voip.h
+++ b/include/audio_stream_voip.h
@@ -15,7 +15,7 @@ private:
     friend class AudioStreamPlaybackVOIP;
 
 protected:
-    static void _bind_methods() {};
+    static void _bind_methods();
 
 public:
     // Overrides

--- a/include/audio_stream_voip.h
+++ b/include/audio_stream_voip.h
@@ -3,7 +3,6 @@
 
 #include <godot_cpp/classes/audio_stream.hpp>
 #include <godot_cpp/classes/audio_stream_playback.hpp>
-#include <godot_cpp/classes/packet_peer.hpp>
 
 
 namespace godot {
@@ -19,11 +18,6 @@ protected:
     static void _bind_methods() {};
 
 public:
-    // Properties
-
-    Ref<PacketPeer> peer_conn; // WARNING: starts null
-
-
     // Overrides
 
     virtual Ref<AudioStreamPlayback> _instantiate_playback() const override;
@@ -33,6 +27,11 @@ public:
     virtual bool _is_monophonic() const override { return true; }
     virtual double _get_bpm() const override { return 0.0; }
     virtual int32_t _get_beat_count() const override { return 0; }
+
+
+    // Methods
+
+    void push_packet(const PackedByteArray&);
 
 };
 

--- a/include/voip_input_capture.h
+++ b/include/voip_input_capture.h
@@ -31,12 +31,6 @@ public:
     void set_volume(const float _volume) { volume = _volume; } // Error condition for outside [0,1]?
     float get_volume() const { return volume; }
 
-
-    // Methods
-
-    Ref<AudioStreamVOIP> add_peer(Ref<PacketPeer> peer);
-    void remove_peer(Ref<PacketPeer> peer);
-
 };
 
 

--- a/include/voip_input_capture.h
+++ b/include/voip_input_capture.h
@@ -2,7 +2,6 @@
 #define VOIP_INPUT_CAPTURE_H
 
 #include <godot_cpp/classes/audio_effect_capture.hpp>
-#include <godot_cpp/classes/packet_peer.hpp>
 
 #include "audio_stream_voip.h"
 

--- a/src/audio_stream_voip.cpp
+++ b/src/audio_stream_voip.cpp
@@ -4,6 +4,14 @@
 using namespace godot;
 
 
+void AudioStreamVOIP::_bind_methods(){
+
+    // Methods
+
+    ClassDB::bind_method(D_METHOD("push_packet", "packet"), &AudioStreamVOIP::push_packet);
+}
+
+
 Ref<AudioStreamPlayback> AudioStreamVOIP::_instantiate_playback() const{
     Ref<AudioStreamPlaybackVOIP> playback;
     playback.instantiate();

--- a/src/audio_stream_voip.cpp
+++ b/src/audio_stream_voip.cpp
@@ -10,3 +10,7 @@ Ref<AudioStreamPlayback> AudioStreamVOIP::_instantiate_playback() const{
     playback->base = Ref<AudioStreamVOIP>(this);
     return playback;
 }
+
+void AudioStreamVOIP::push_packet(const PackedByteArray& packet){
+
+}

--- a/src/voip_input_capture.cpp
+++ b/src/voip_input_capture.cpp
@@ -36,8 +36,8 @@ void VOIPInputCapture::_bind_methods(){
     ClassDB::add_signal(
         "VOIPInputCapture",
         MethodInfo(
-            PropertyInfo(Variant::PACKED_BYTE_ARRAY, "audio_packet", PROPERTY_HINT_NONE, "", 6U, "bytearray"),
-            "packet_ready"
+            "packet_ready",
+            PropertyInfo(Variant::PACKED_BYTE_ARRAY, "audio_packet", PROPERTY_HINT_NONE, "", 6U, "bytearray")
         )
     );
 

--- a/src/voip_input_capture.cpp
+++ b/src/voip_input_capture.cpp
@@ -31,16 +31,14 @@ void VOIPInputCapture::_bind_methods(){
     );
 
 
-    // Methods
+    // Signals
 
-    ClassDB::bind_method(D_METHOD("add_peer"), &VOIPInputCapture::add_peer);
-    ClassDB::bind_method(D_METHOD("remove_peer"), &VOIPInputCapture::remove_peer);
+    ClassDB::add_signal(
+        "VOIPInputCapture",
+        MethodInfo(
+            PropertyInfo(Variant::PACKED_BYTE_ARRAY, "audio_packet", PROPERTY_HINT_NONE, "", 6U, "bytearray"),
+            "packet_ready"
+        )
+    );
 
-}
-
-Ref<AudioStreamVOIP> VOIPInputCapture::add_peer(Ref<PacketPeer> peer) {
-    return new Ref<AudioStreamVOIP>();
-}
-
-void VOIPInputCapture::remove_peer(Ref<PacketPeer> peer){
 }

--- a/src/voip_input_capture.cpp
+++ b/src/voip_input_capture.cpp
@@ -7,10 +7,10 @@ void VOIPInputCapture::_bind_methods(){
 
     // Property Get / Set
 
-    ClassDB::bind_method(D_METHOD("set_muted"), &VOIPInputCapture::set_muted);
+    ClassDB::bind_method(D_METHOD("set_muted", "muted"), &VOIPInputCapture::set_muted);
     ClassDB::bind_method(D_METHOD("is_muted"), &VOIPInputCapture::is_muted);
 
-    ClassDB::bind_method(D_METHOD("set_volume"), &VOIPInputCapture::set_volume);
+    ClassDB::bind_method(D_METHOD("set_volume", "volume"), &VOIPInputCapture::set_volume);
     ClassDB::bind_method(D_METHOD("get_volume"), &VOIPInputCapture::get_volume);
 
 


### PR DESCRIPTION
PacketPeer sucks as an interface, we would only be able to use it if we casted it to figure out whether it was a WebRTCDataChannel or some kind of ENet peer, in which case we would have to check every single packet to see if it matched the channel that we would have to somehow take as an extra argument

head hurts

no more networking