### PR TITLE
Set AudioStreamVOIP as local to scene

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ stream.push_packet(packet)
 
 Check out the demos for a full example.
 
+If you use the demo ensure that AudioStreamPlayer uses unique AudioStreamVOIP making it local to scene.
+
 ## Compiling
 
 ### Windows

--- a/demo/user.tscn
+++ b/demo/user.tscn
@@ -1,6 +1,7 @@
 [gd_scene load_steps=2 format=3 uid="uid://e8q0gjrr45rq"]
 
 [sub_resource type="AudioStreamVOIP" id="AudioStreamVOIP_fqv3d"]
+resource_local_to_scene = true
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer"]
 stream = SubResource("AudioStreamVOIP_fqv3d")

--- a/demo_rtc/user.tscn
+++ b/demo_rtc/user.tscn
@@ -1,6 +1,7 @@
 [gd_scene load_steps=2 format=3 uid="uid://e8q0gjrr45rq"]
 
 [sub_resource type="AudioStreamVOIP" id="AudioStreamVOIP_fqv3d"]
+resource_local_to_scene = true
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer"]
 stream = SubResource("AudioStreamVOIP_fqv3d")


### PR DESCRIPTION
Fixes #16 
The problem in issue was I believe because two AudioStreamPlayer's where referring to the same AudioStreamVOIP resource meaning they used shared jitter_buffer, although they had different AudioStreamPlaybackVOIP's instantiated

Solutions is to set resource as local to scene, so it’s unique for each audio player
I think it's worth mentioning this in the docs
![Screenshot from 2024-02-29 11-30-53](https://github.com/RevoluPowered/one-voip-godot-4/assets/54914954/55a4fda5-6951-4d4b-92ae-b94f9ba8f685)
*Screenshot from my project